### PR TITLE
Fix an typo error in ops.py

### DIFF
--- a/ops.py
+++ b/ops.py
@@ -78,7 +78,7 @@ def conv2d_transpose(input_, output_shape,
                      name="conv2d_transpose", with_w=False):
     with tf.variable_scope(name):
         # filter : [height, width, output_channels, in_channels]
-        w = tf.get_variable('w', [k_h, k_h, output_shape[-1], input_.get_shape()[-1]],
+        w = tf.get_variable('w', [k_h, k_w, output_shape[-1], input_.get_shape()[-1]],
                             initializer=tf.random_normal_initializer(stddev=stddev))
 
         try:


### PR DESCRIPTION
There is (maybe) a typo error in ops.py, in function `conv2d_transpose(...)`:
```python
w = tf.get_variable('w', [k_h, k_h, output_shape[-1], input_.get_shape()[-1]], ...)
```
It seems that the second `k_h` should be `k_w`, although it has no effect on the codes (since both `k_h` and `k_w` are set to 5).